### PR TITLE
Take care of clippy issues

### DIFF
--- a/src/cloudwatch/bucket_metrics.rs
+++ b/src/cloudwatch/bucket_metrics.rs
@@ -70,7 +70,7 @@ impl From<Vec<Metric>> for BucketMetrics {
             // new one if it doesn't exist yet.
             let storage_types = bucket_metrics
                 .entry(name)
-                .or_insert_with(|| StorageTypes::new());
+                .or_insert_with(StorageTypes::new);
 
             // Push the new storage type into the vec
             storage_types.push(storage_type);

--- a/src/cloudwatch/client.rs
+++ b/src/cloudwatch/client.rs
@@ -153,7 +153,6 @@ impl Client {
                 metric_name: Some("BucketSizeBytes".into()),
                 namespace:   Some("AWS/S3".into()),
                 next_token:  next_token,
-                ..Default::default()
             };
 
             // Call the API

--- a/src/s3/client.rs
+++ b/src/s3/client.rs
@@ -119,10 +119,7 @@ impl Client {
 
         debug!("head_bucket output for '{}' -> '{:?}'", bucket, output);
 
-        match output {
-            Ok(_)  => true,
-            Err(_) => false,
-        }
+        output.is_ok()
     }
 
     /// Returns a bool indicating if the region is a custom region


### PR DESCRIPTION
This PR fixes some clippy issues:
  - Replaces a match with `is_ok`
  - Removes a `..Default::default()` from a struct that was already fully initialized
  - Replaces a closure with a function when using the hashmap entry API